### PR TITLE
redirects.md translated

### DIFF
--- a/redirects.md
+++ b/redirects.md
@@ -1,95 +1,120 @@
 # HTTP Redirects
 
-- [Creating Redirects](#creating-redirects)
-- [Redirecting To Named Routes](#redirecting-named-routes)
-- [Redirecting To Controller Actions](#redirecting-controller-actions)
-- [Redirecting With Flashed Session Data](#redirecting-with-flashed-session-data)
+- [إنشاء عمليات إعادة التوجيه (Redirects)](#creating-redirects)
+- [ إعادة التوجيه لمسارات (routes) ذات أسماء](#redirecting-named-routes)
+- [ إعادة التوجيه لعمليات المتحكم (controller actions)](#redirecting-controller-actions)
+- [إعادة التوجيه مع بيانات مخزنة مؤقتاً في الجلسة (Flashed Session Data)](#redirecting-with-flashed-session-data)
 
 <a name="creating-redirects"></a>
-## Creating Redirects
+## إنشاء عمليات إعادة التوجيه (Redirects)
 
-Redirect responses are instances of the `Illuminate\Http\RedirectResponse` class, and contain the proper headers needed to redirect the user to another URL. There are several ways to generate a `RedirectResponse` instance. The simplest method is to use the global `redirect` helper:
+إن ردود إعادة التوجيه (redirect responses) هي نُسخ (instances) من الكائن `Illuminate\Http\RedirectResponse` تحتوي على الترويسات (headers) المطلوبة لإعادة توجيه المستخدم لرابط URL أخر. يوجد عدة طرق لإنشاء نسخة من الكائن `RedirectResponse` وأبسطها هو استعمال التابع المساعد `redirect`: 
 
-    Route::get('/dashboard', function () {
-        return redirect('/home/dashboard');
-    });
+```php
+Route::get('/dashboard', function () {
+    return redirect('/home/dashboard');
+});
+```
 
-Sometimes you may wish to redirect the user to their previous location, such as when a submitted form is invalid. You may do so by using the global `back` helper function. Since this feature utilizes the [session](/docs/{{version}}/session), make sure the route calling the `back` function is using the `web` middleware group or has all of the session middleware applied:
+أحياناً قد ترغب بإعادة توجيه المستخدمين لموقعهم السابق، كما في حالة إرسالهم لبيانات استمارة (form) خاطئة. يمكنك ذلك باستخدام التابع المساعد `back`. وبما أن هذه الميزة تعتمد على [الجلسة (session)](/docs/{{version}}/session) تأكد بأن استدعاء التابع `back` يستعمل مجموعة البرمجيات الوسيطة (middleware group) التالية `web` أو أنه يخضع لتطبيق جميع البرمجيات الوسيطة (middleware) الخاصة بالجلسة: 
 
-    Route::post('/user/profile', function () {
-        // Validate the request...
-
-        return back()->withInput();
-    });
-
-<a name="redirecting-named-routes"></a>
-## Redirecting To Named Routes
-
-When you call the `redirect` helper with no parameters, an instance of `Illuminate\Routing\Redirector` is returned, allowing you to call any method on the `Redirector` instance. For example, to generate a `RedirectResponse` to a named route, you may use the `route` method:
-
-    return redirect()->route('login');
-
-If your route has parameters, you may pass them as the second argument to the `route` method:
-
-    // For a route with the following URI: profile/{id}
-
-    return redirect()->route('profile', ['id' => 1]);
-
-<a name="populating-parameters-via-eloquent-models"></a>
-#### Populating Parameters Via Eloquent Models
-
-If you are redirecting to a route with an "ID" parameter that is being populated from an Eloquent model, you may pass the model itself. The ID will be extracted automatically:
-
-    // For a route with the following URI: profile/{id}
-
-    return redirect()->route('profile', [$user]);
-
-If you would like to customize the value that is placed in the route parameter, you should override the `getRouteKey` method on your Eloquent model:
-
-    /**
-     * Get the value of the model's route key.
-     *
-     * @return mixed
-     */
-    public function getRouteKey()
-    {
-        return $this->slug;
-    }
-
-<a name="redirecting-controller-actions"></a>
-## Redirecting To Controller Actions
-
-You may also generate redirects to [controller actions](/docs/{{version}}/controllers). To do so, pass the controller and action name to the `action` method:
-
-    use App\Http\Controllers\HomeController;
-
-    return redirect()->action([HomeController::class, 'index']);
-
-If your controller route requires parameters, you may pass them as the second argument to the `action` method:
-
-    return redirect()->action(
-        [UserController::class, 'profile'], ['id' => 1]
-    );
-
-<a name="redirecting-with-flashed-session-data"></a>
-## Redirecting With Flashed Session Data
-
-Redirecting to a new URL and [flashing data to the session](/docs/{{version}}/session#flash-data) are usually done at the same time. Typically, this is done after successfully performing an action when you flash a success message to the session. For convenience, you may create a `RedirectResponse` instance and flash data to the session in a single, fluent method chain:
-
-    Route::post('/user/profile', function () {
-        // Update the user's profile...
-
-        return redirect('/dashboard')->with('status', 'Profile updated!');
-    });
-
-You may use the `withInput` method provided by the `RedirectResponse` instance to flash the current request's input data to the session before redirecting the user to a new location. Once the input has been flashed to the session, you may easily [retrieve it](/docs/{{version}}/requests#retrieving-old-input) during the next request:
+```php
+Route::post('/user/profile', function () {
+    // Validate the request...
 
     return back()->withInput();
+});
+```
 
-After the user is redirected, you may display the flashed message from the [session](/docs/{{version}}/session). For example, using [Blade syntax](/docs/{{version}}/blade):
+<a name="redirecting-named-routes"></a>
+##  إعادة التوجيه لمسارات (routes) ذات أسماء
 
-    @if (session('status'))
-        <div class="alert alert-success">
-            {{ session('status') }}
-        </div>
-    @endif
+عندما تستخدم التابع المساعد `redirect` بدون تمرير وسطاء سيتم إعادة نسخة (instance) من نوع `Illuminate\Routing\Redirector`، مما يسمح لك باستدعاء أي طريقة على النسخة `Redirector`. على سبيل المثال لإنشاء رد `RedirectResponse` على مسار ذو اسم (named route) يمكنك استخدام الطريقة `route`: 
+
+```php
+return redirect()->route('login');
+```
+
+وفي حال كون المسار (route) يحتوي على وسطاء يمكنك تمريرهم كوسيط ثانٍ للطريقة `route`: 
+
+```php
+// For a route with the following URI: profile/{id}
+
+return redirect()->route('profile', ['id' => 1]);
+```
+
+<a name="populating-parameters-via-eloquent-models"></a>
+#### تمرير النماذج (Eloquent Models) كوسطاء
+
+اذا كنت تعيد التوجيه لمسار (route) يحوي على وسيط  "ID" خاص بنموذج (Eloquent Model)، يمكنك تمرير النموذج (model) نفسه. حيث أنه سيتم استخراج الخاصية "ID" تلقائياً:
+
+
+```php
+// For a route with the following URI: profile/{id}
+
+return redirect()->route('profile', [$user]);
+```
+
+اذا كنت تريد تغيير القيمة التي يتم استخراجها عند تمرير النموذج كوسيط للمسار (route) يجب عليك عمل override للطريقة `getRouteKey` في النموذج (Eloquent Model) الخاص بك.: 
+
+
+```php
+/**
+ * Get the value of the model's route key.
+ *
+ * @return mixed
+ */
+public function getRouteKey()
+{
+    return $this->slug;
+}
+```
+
+<a name="redirecting-controller-actions"></a>
+## إعادة التوجيه لعمليات المتحكم (Controller actions)
+
+يمكنك أيضاً إنشاء إعادة توجيه (redirect) [لعمليات متحكم (controller actions)](/docs/{{version}}/controllers) عن طريق تمرير المتحكم واسم العملية للطريقة `action`: 
+
+
+```php
+use App\Http\Controllers\HomeController;
+
+return redirect()->action([HomeController::class, 'index']);
+```
+
+في حال كان مسار المتحكم يحتاج لوسطاء يمكنك تمريرهم كوسيط ثانٍ للطريقة `action`:
+
+```php
+return redirect()->action(
+    [UserController::class, 'profile'], ['id' => 1]
+);
+```
+
+<a name="redirecting-with-flashed-session-data"></a>
+## إعادة التوجيه مع بيانات مخزنة مؤقتاً في الجلسة (Flashed Session Data) 
+
+إن عملية إعادة التوجيه لرابط (URL) جديد مع [تخزين بيانات بشكل مؤقت في الجلسة (flashing data to the session)](/docs/{{version}}/session#flash-data) يتم عادة بنفس الوقت. ويتم ذلك بعد تنفيذ إجراء ما بنجاح فتقوم بتخزين رسالة نجاح في الجلسة (session). للسهولة يمكنك انشاء نسخة (instance) من الكائن `RedirectResponse` وتخزينها مؤقتاً في الجلسة في طريقة فردية سلسة ومتسلسلة: 
+
+```php
+Route::post('/user/profile', function () {
+    // Update the user's profile...
+
+    return redirect('/dashboard')->with('status', 'Profile updated!');
+});
+```
+
+يمكنك استخدام الطريقة `withInput` التي تقدمها النسخة (instance) من الكائن `RedirectResponse` لتخزين بيانات الدخل الخاصة بالطلب (request) الحالي في الجلسة قبل إعادة توجيه المستخدم لمكان جديد. وعندما يتم تخزين البيانات في الجلسة يمكنك [استعادتها](/docs/{{version}}/requests#retrieving-old-input) بسهولة خلال الطلب (request) التالي: 
+
+```php
+return back()->withInput();
+```
+
+بعد إعادة توجيه المستخدم يمكنك عرض الرسالة التي تم تخزينها مؤقتاً في [الجلسة](/docs/{{version}}/session). على سبيل المثال باستخدام [تركيب Blade](/docs/{{version}}/blade) التالي: 
+
+```php
+@if (session('status'))
+    <div class="alert alert-success">
+        {{ session('status') }}
+    </div>
+@endif
+```

--- a/redirects.md
+++ b/redirects.md
@@ -111,7 +111,7 @@ return back()->withInput();
 
 بعد إعادة توجيه المستخدم يمكنك عرض الرسالة التي تم تخزينها مؤقتاً في [الجلسة](/docs/{{version}}/session). على سبيل المثال باستخدام [تركيب Blade](/docs/{{version}}/blade) التالي: 
 
-```php
+```blade
 @if (session('status'))
     <div class="alert alert-success">
         {{ session('status') }}


### PR DESCRIPTION
I had some issues translating the following phrases/words :
* "Populating Parameters Via Eloquent Models".
* "override" I would use "إعادة تعريف الطريقة" but I'm open to suggestions for better translations.
* "Flashed Session Data" I know it's data that is stored in the session for the next request only, but I didn't find a better word than "تخزين مؤقت" to translate "Flashing", also open for suggestions .

Waiting for review to submit new words to dictionary.